### PR TITLE
Work with can-define

### DIFF
--- a/can-view-autorender.js
+++ b/can-view-autorender.js
@@ -19,7 +19,14 @@ function isIn(element, type) {
 function setAttr(el, attr, scope){
 	var camelized = camelize(attr);
 	if (!ignoreAttributesRegExp.test(camelized) ) {
-		scope.attr(camelized, el.getAttribute(attr));
+		var value = el.getAttribute(attr);
+		if(scope.attr) {
+			scope.attr(camelized, value);
+		} else if(scope.set) {
+			scope.set(camelized, value);
+		} else {
+			scope[camelized] = value;
+		}
 	}
 }
 function insertAfter(ref, element) {
@@ -67,8 +74,6 @@ var promise = new Promise(function(resolve, reject) {
 				typeInfo = typeAttr.match( typeMatch ),
 				type = typeInfo && typeInfo[1],
 				typeModule = "can-" + type;
-
-			console.log(typeModule);
 
 			promises.push(importer(typeModule).then(function(engine){
 				if(engine.async) {

--- a/can-view-autorender_test.js
+++ b/can-view-autorender_test.js
@@ -17,6 +17,10 @@ var makeIframe = function(src){
 	iframe.src = src;
 };
 
+var get = function(map, prop) {
+	return map.attr ? map.attr(prop) : map.get(prop);
+};
+
 var makeBasicTestIframe = function(src){
 	var iframe = document.createElement('iframe');
 	window.removeMyself = function(){
@@ -35,7 +39,7 @@ var makeBasicTestIframe = function(src){
 		equal(el[0].innerHTML, "Hello World","template rendered");
 		// equal(el[0].className, "inserted","template rendered");
 
-		equal(scope.attr("message"), "Hello World", "Scope correctly setup");
+		equal(get(scope, "message"), "Hello World", "Scope correctly setup");
 		window.removeMyself();
 	};
 	document.body.appendChild(iframe);
@@ -50,4 +54,8 @@ QUnit.asyncTest("the basics are able to work for steal", function(){
 
 QUnit.asyncTest("autoload loads a jquery viewmodel fn", function(){
 	makeIframe(__dirname + "/test/steal-viewmodel.html?" + Math.random());
+});
+
+QUnit.asyncTest("works with a can-define/map/map", function(){
+	makeBasicTestIframe(__dirname + "/test/define.html?" + Math.random());
 });

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "can-component": "^3.0.0-pre.3",
+    "can-define": "^0.7.4",
     "can-stache": "^3.0.0-pre.4",
     "cssify": "^0.6.0",
     "documentjs": "^0.4.2",

--- a/test/define.html
+++ b/test/define.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head>
+  <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
+</head>
+<body>
+
+<script>
+  window.isReady = window.parent.isReady || function(el) {
+    console.log(el.length);
+    console.log(el.innerHTML);
+  };
+  window.hasError = window.parent.hasError || function(error) {
+    console.log(error.stack);
+    console.log("error in autoload", error)
+  };
+  window.removeMyself = window.parent.removeMyself;
+</script>
+<script type='text/stache' id='basics' foo='bar' can-autorender>
+  <can-import from="can-view-autorender/test/define"/>
+  <my-component></my-component>
+</script>
+<script src='../node_modules/steal/steal.js' main='@empty'></script>
+<script src='../../../node_modules/steal/steal.js' main='@empty'></script>
+<script>
+	steal.done().then(function() {
+		System.import('can-view-autorender').then(function(ready) {
+			System.import('can-view-model').then(function(viewModel) {
+				ready(function() {
+					var myComponents = document.body.querySelectorAll("my-component");
+					isReady(myComponents, viewModel(myComponents[0]));
+				}, hasError);
+			});
+		});
+	});
+</script>
+
+</body>
+</html>

--- a/test/define.js
+++ b/test/define.js
@@ -1,0 +1,16 @@
+var Component = require('can-component');
+var stache = require('can-stache');
+var DefineMap = require('can-define/map/map');
+
+var MyMap = DefineMap.extend({
+	message: {
+		value: "Hello World"
+	}
+});
+
+module.exports = Component.extend({
+	tag: "my-component",
+	// call can.stache b/c it should be imported auto-magically
+	template: stache("{{message}}"),
+	ViewModel: MyMap
+});


### PR DESCRIPTION
This makes autorender work with can-define/map/map. Instead of calling
`.attr` to set the property, check if `.attr` exist or else use `.set`