### PR TITLE
Fix scope to viewModel property for test

### DIFF
--- a/test/basics.js
+++ b/test/basics.js
@@ -6,9 +6,7 @@ module.exports = Component.extend({
 	tag: "my-component",
 	// call can.stache b/c it should be imported auto-magically
 	view: stache("{{message}}"),
-	scope: function(){
-		return new SimpleMap({
-			message: "Hello World"
-		});
-	}
+	viewModel: new SimpleMap({
+		message: "Hello World"
+	})
 });


### PR DESCRIPTION
`scope` is deprecated so the test failed in general.