### PR TITLE
Removing cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-view-autorender",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "canjs-plugin",
@@ -58,7 +48,6 @@
     "can-component": "^3.0.0-pre.3",
     "can-define": "^1.0.1",
     "can-stache": "^3.0.0-pre.19",
-    "cssify": "^1.0.2",
     "bit-docs": "0.0.6",
     "done-serve": "^0.2.0",
     "donejs-cli": "^0.9.4",


### PR DESCRIPTION
cssify is not used in this project and breaks Browserify.