### PR TITLE
Hide docs that can’t show up in the navigation

### DIFF
--- a/autorender.md
+++ b/autorender.md
@@ -1,5 +1,6 @@
 @module {function()} can/view/autorender can.autorender
 @parent can.view.plugins
+@hide
 
 A module that automatically renders script and other elements with
 the [can/view/autorender.can-autorender] attribute. This function is useful to know when


### PR DESCRIPTION
It looks like these might be a duplicate of what’s in `can-view-autorender.md`; can `autorender.md` be deleted?

Part of https://github.com/canjs/canjs/issues/3660