### PR TITLE
Remove dependencies on can-util

### DIFF
--- a/can-view-autorender.js
+++ b/can-view-autorender.js
@@ -1,9 +1,9 @@
-var canViewModel = require("can-view-model");
-var camelize = require("can-util/js/string/string").camelize;
-var each = require("can-util/js/each/each");
-var importer = require("can-util/js/import/import");
 var namespace = require("can-namespace");
-var domEvents = require("can-util/dom/events/events");
+var canViewModel = require("can-view-model");
+var canReflect = require("can-reflect");
+var camelize = require("can-string").camelize;
+var importer = require("can-importer");
+var domEvents = require("can-dom-events");
 
 var ignoreAttributesRegExp = /^(dataViewId|class|id|type|src)$/i;
 
@@ -51,11 +51,11 @@ function render(renderer, scope, el) {
 function setupScope(el) {
 	var scope = canViewModel(el);
 
-	each(el.attributes || [], function(attr) {
+	canReflect.each(el.attributes || [], function(attr) {
 		setAttr(el, attr.name, scope);
 	});
 
-	domEvents.addEventListener.call(el, "attributes", function(ev) {
+	domEvents.addEventListener(el, "attributes", function(ev) {
 		setAttr(el, ev.attributeName, scope);
 	});
 
@@ -66,7 +66,7 @@ var promise = new Promise(function(resolve, reject) {
 	function autoload(){
 		var promises = [];
 
-		each( document.querySelectorAll("[can-autorender]"), function( el, i){
+		canReflect.each(document.querySelectorAll("[can-autorender]"), function( el, i){
 			el.style.display = "none";
 
 			var text = el.innerHTML || el.text,
@@ -94,7 +94,7 @@ var promise = new Promise(function(resolve, reject) {
 	if (document.readyState === "complete") {
 		autoload();
 	} else {
-		domEvents.addEventListener.call(window, "load", autoload);
+		domEvents.addEventListener(window, "load", autoload);
 	}
 });
 

--- a/can-view-autorender.js
+++ b/can-view-autorender.js
@@ -2,7 +2,7 @@ var namespace = require("can-namespace");
 var canViewModel = require("can-view-model");
 var canReflect = require("can-reflect");
 var camelize = require("can-string").camelize;
-var importer = require("can-importer");
+var load = require("can-import-module");
 var domEvents = require("can-dom-events");
 
 var ignoreAttributesRegExp = /^(dataViewId|class|id|type|src)$/i;
@@ -75,7 +75,7 @@ var promise = new Promise(function(resolve, reject) {
 				type = typeInfo && typeInfo[1],
 				typeModule = "can-" + type;
 
-			promises.push(importer(typeModule).then(function(engine){
+			promises.push(load(typeModule).then(function(engine){
 				if(engine.async) {
 					return engine.async(text).then(function(renderer){
 						render(renderer, setupScope(el), el);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "can-importer": "^1.0.0",
     "can-namespace": "1.0.0",
     "can-reflect": "^1.15.2",
-    "can-string": "0.0.4",
+    "can-string": "<2.0.0",
     "can-view-model": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "can-namespace": "1.0.0",
     "can-reflect": "^1.15.2",
     "can-string": "0.0.4",
-    "can-util": "^3.9.5",
     "can-view-model": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,11 @@
     "donejs"
   ],
   "dependencies": {
+    "can-dom-events": "^1.2.0",
+    "can-importer": "^1.0.0",
     "can-namespace": "1.0.0",
+    "can-reflect": "^1.15.2",
+    "can-string": "0.0.4",
     "can-util": "^3.9.5",
     "can-view-model": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "can-dom-events": "^1.2.0",
-    "can-importer": "^1.0.0",
+    "can-import-module": "^1.0.0",
     "can-namespace": "1.0.0",
     "can-reflect": "^1.15.2",
     "can-string": "<2.0.0",


### PR DESCRIPTION
This removes the remaining can-util dependencies. This will be a 5.0 change.