### PR TITLE
Allow script properties to be set on sealed objects

### DIFF
--- a/can-view-autorender.js
+++ b/can-view-autorender.js
@@ -5,7 +5,7 @@ var camelize = require("can-string").camelize;
 var load = require("can-import-module");
 var domEvents = require("can-dom-events");
 
-var ignoreAttributesRegExp = /^(dataViewId|class|id|type|src)$/i;
+var ignoreAttributesRegExp = /^(dataViewId|class|id|type|src|style)$/i;
 
 var typeMatch = /\s*text\/(stache)\s*/;
 function isIn(element, type) {
@@ -16,17 +16,15 @@ function isIn(element, type) {
 		}
 	}
 }
-function setAttr(el, attr, scope){
+function setAttr(el, attr, viewModel){
 	var camelized = camelize(attr);
 	if (!ignoreAttributesRegExp.test(camelized) ) {
 		var value = el.getAttribute(attr);
-		if(scope.attr) {
-			scope.attr(camelized, value);
-		} else if(scope.set) {
-			scope.set(camelized, value);
-		} else {
-			scope[camelized] = value;
+
+		if(!canReflect.hasKey(viewModel, camelized)) {
+			canReflect.defineInstanceKey(viewModel.constructor, camelized, typeof value);
 		}
+		canReflect.setKeyValue(viewModel, camelized, value);
 	}
 }
 function insertAfter(ref, element) {

--- a/can-view-autorender_test.js
+++ b/can-view-autorender_test.js
@@ -30,6 +30,9 @@ var makeBasicTestIframe = function(src){
 		document.body.removeChild(iframe);
 		start();
 	};
+	window.assertOk = function() {
+		ok.apply(null, arguments);
+	};
 	window.hasError = function(error) {
 		ok(false, error.message || error);
 		window.removeMyself();
@@ -58,5 +61,9 @@ if (__dirname !== '/') {
 
 	QUnit.asyncTest("works with a can-define/map/map", function(){
 		makeBasicTestIframe(__dirname + "/test/define.html?" + Math.random());
+	});
+
+	QUnit.asyncTest("does not set can-autorender property on sealed ViewModels", function(){
+		makeBasicTestIframe(__dirname + "/test/define2.html?" + Math.random());
 	});
 }

--- a/test/define2.html
+++ b/test/define2.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+<head>
+  <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
+</head>
+<body>
+
+<script>
+	window.assertOk = window.parent.assertOk || function(){};
+  window.removeMyself = window.parent.removeMyself || function(){};
+</script>
+<script type='text/stache' id='basics' first="Matthew" can-autorender>
+	<div id="name">{{first}} {{last}}</div>
+</script>
+<script src='../node_modules/steal/steal.js' main='@empty'></script>
+<script src='../../../node_modules/steal/steal.js' main='@empty'></script>
+<script>
+	steal.import('can-view-autorender', 'can-view-model', "can-define/map/map")
+	.then(function(modules) {
+		var canViewAutorender = modules[0];
+		var canViewModel = modules[1];
+		var DefineMap = modules[2];
+
+		var MyMap = DefineMap.extend({
+			first: "string",
+			last: "string"
+		});
+
+		var el = document.querySelector("#basics");
+		canViewModel(el, new MyMap({ last: "Phillips" }));
+
+		canViewAutorender(function(){
+			var txt = document.getElementById("name").textContent;
+			assertOk(txt, "Matthew Phillips");
+			removeMyself();
+		});
+	});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This change uses defineInstanceKey to define properties on viewModel if
the viewModel doesn't already have a definition.

Also uses setKeyValue to set the value.

Closes #92 and #5