### PR TITLE
using steal-with-promises for scripts loaded by canjs/canjs test suite

### DIFF
--- a/test/basics.html
+++ b/test/basics.html
@@ -21,7 +21,7 @@
   <my-component></my-component>
 </script>
 <script src='../node_modules/steal/steal.js' main='@empty'></script>
-<script src='../../../node_modules/steal/steal.js' main='@empty'></script>
+<script src='../../../node_modules/steal/steal-with-promises.js' main='@empty'></script>
 <script>
 	steal.done().then(function() {
 		System.import('can-view-autorender').then(function(ready) {

--- a/test/define.html
+++ b/test/define.html
@@ -21,7 +21,7 @@
   <my-component></my-component>
 </script>
 <script src='../node_modules/steal/steal.js' main='@empty'></script>
-<script src='../../../node_modules/steal/steal.js' main='@empty'></script>
+<script src='../../../node_modules/steal/steal-with-promises.js' main='@empty'></script>
 <script>
 	steal.done().then(function() {
 		System.import('can-view-autorender').then(function(ready) {

--- a/test/define2.html
+++ b/test/define2.html
@@ -13,7 +13,7 @@
 	<div id="name">{{first}} {{last}}</div>
 </script>
 <script src='../node_modules/steal/steal.js' main='@empty'></script>
-<script src='../../../node_modules/steal/steal.js' main='@empty'></script>
+<script src='../../../node_modules/steal/steal-with-promises.js' main='@empty'></script>
 <script>
 	steal.import('can-view-autorender', 'can-view-model', "can-define/map/map")
 	.then(function(modules) {

--- a/test/steal-viewmodel.html
+++ b/test/steal-viewmodel.html
@@ -24,8 +24,8 @@
 	<script type='text/stache' id='basics' foo='bar' can-autorender>
 		<h1>{{message}}</h1>
 	</script>
-	<script src='../../../node_modules/steal/steal.js' main='@empty'></script>
 	<script src='../node_modules/steal/steal.js' main='@empty'></script>
+	<script src='../../../node_modules/steal/steal-with-promises.js' main='@empty'></script>
 	<script>
 		steal.done().then(function() {
 			System.import('can-view-autorender').then(function(ready) {


### PR DESCRIPTION
canjs/canjs is using Steal 2.0, so we need to use the -with-promises
version of steal so tests will work in browsers without native Promises.